### PR TITLE
Identitypool roles structfix

### DIFF
--- a/cognito/identitypool-roles/README.md
+++ b/cognito/identitypool-roles/README.md
@@ -119,10 +119,11 @@ Resources:
         - IdentityProvider: !Sub "cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}:${UserPoolClient.ClientId}"
           Type: "Rules"
           AmbiguousRoleResolution: "Deny"
-          Rules:
-            - Claim: "group"
-              MatchType: "Equals"
-              Value: "testGroup"
-              RoleArn: !GetAtt "MappedRole.Arn"
+          RulesConfiguration:
+            Rules:
+              - Claim: "group"
+                MatchType: "Equals"
+                Value: "testGroup"
+                RoleArn: !GetAtt "MappedRole.Arn"
       ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:cognito-identitypool-roles-${AWS::Region}-${Environment}"
 ```

--- a/cognito/identitypool-roles/main.go
+++ b/cognito/identitypool-roles/main.go
@@ -41,10 +41,14 @@ type IdentityPoolRoles struct {
 
 // RoleMapping contains the role mappings for a identity provider.
 type RoleMapping struct {
-	IdentityProvider        string `json:"IdentityProvider"`
-	Type                    string `json:"Type"`
-	AmbiguousRoleResolution string `json:"AmbiguousRoleResolution"`
-	Rules                   []Rule `json:"Rules,omitempty"`
+	IdentityProvider        string             `json:"IdentityProvider"`
+	Type                    string             `json:"Type"`
+	AmbiguousRoleResolution string             `json:"AmbiguousRoleResolution"`
+	RulesConfiguration      RulesConfiguration `json:"RulesConfiguration"`
+}
+
+type RulesConfiguration struct {
+	Rules []Rule `json:"Rules,omitempty"`
 }
 
 // Rule contains the rules if you're using rules based role mapping.

--- a/cognito/identitypool-roles/set.go
+++ b/cognito/identitypool-roles/set.go
@@ -67,6 +67,8 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 
 			// Validate rules.
 			for _, rule := range mapping.RulesConfiguration.Rules {
+				log.Printf("rule: %+v", rule)
+
 				switch {
 				case rule.Claim == "":
 					return fmt.Errorf("No Claim set in Rules")
@@ -95,7 +97,7 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 	}
 
 	// Send the request.
-	log.Printf("%+v", input)
+	log.Printf("input: %+v", input)
 	_, err := c.svc.SetIdentityPoolRolesRequest(input).Send()
 	if err != nil {
 		return fmt.Errorf("Failed to set Identity Pool Roles. Error %s", err.Error())

--- a/cognito/identitypool-roles/set.go
+++ b/cognito/identitypool-roles/set.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
 
@@ -89,8 +88,6 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 					Value:     &rule.Value,
 					RoleARN:   &rule.RoleArn,
 				})
-
-				log.Printf("mapping rules: %+v", r.RulesConfiguration.Rules)
 			}
 
 			// Set the rule to RoleMappings map.
@@ -99,7 +96,6 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 	}
 
 	// Send the request.
-	log.Printf("input: %+v", input)
 	_, err := c.svc.SetIdentityPoolRolesRequest(input).Send()
 	if err != nil {
 		return fmt.Errorf("Failed to set Identity Pool Roles. Error %s", err.Error())

--- a/cognito/identitypool-roles/set.go
+++ b/cognito/identitypool-roles/set.go
@@ -89,6 +89,8 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 					Value:     &rule.Value,
 					RoleARN:   &rule.RoleArn,
 				})
+
+				log.Printf("mapping rules: %+v", r.RulesConfiguration.Rules)
 			}
 
 			// Set the rule to RoleMappings map.

--- a/cognito/identitypool-roles/set.go
+++ b/cognito/identitypool-roles/set.go
@@ -66,8 +66,8 @@ func (c *config) setRoles(req *events.Request, defaults bool) error {
 			r.RulesConfiguration = &cognitoidentity.RulesConfigurationType{Rules: []cognitoidentity.MappingRule{}}
 
 			// Validate rules.
-			for _, rule := range mapping.RulesConfiguration.Rules {
-				log.Printf("rule: %+v", rule)
+			for i, _ := range mapping.RulesConfiguration.Rules {
+				rule := mapping.RulesConfiguration.Rules[i]
 
 				switch {
 				case rule.Claim == "":


### PR DESCRIPTION
The
range mapping.RulesConfiguration.Rules{}

loop was leaking resources causing the same element to be appended over and over to the Rules slice.